### PR TITLE
adapt to Gtk v0.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - "1.6"
           - "1"
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GtkMarkdownTextView"
 uuid = "26d59822-f2b6-4a0d-bae1-4d8fc12fd86b"
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 Gtk4 = "9db2cae5-386f-4011-9d63-a5602296539b"
@@ -8,8 +8,8 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
 Gtk4 = "0.7"
-julia = "1.6"
-Markdown = "1.6"
+julia = "1.10"
+Markdown = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ Gtk4 = "9db2cae5-386f-4011-9d63-a5602296539b"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [compat]
-Gtk4 = "0.5, 0.6"
+Gtk4 = "0.7"
 julia = "1.6"
 Markdown = "1.6"
 

--- a/src/GtkMarkdownTextView.jl
+++ b/src/GtkMarkdownTextView.jl
@@ -1,7 +1,7 @@
 module GtkMarkdownTextView
 
     using Gtk4
-    import Gtk4: _GtkTextIter, create_tag, apply_tag
+    import Gtk4: create_tag, apply_tag
     import Gtk4.GLib: gobject_move_ref, GObject
 
     using Markdown
@@ -71,7 +71,7 @@ module GtkMarkdownTextView
     
     function tag(buffer, what, i, j)
         apply_tag(buffer, what, 
-            _GtkTextIter(buffer, i), _GtkTextIter(buffer, j) 
+            GtkTextIter(buffer, i), GtkTextIter(buffer, j) 
         )
     end
 


### PR DESCRIPTION
Gtk4 version 0.7 has breaking changes for any methods that take a GtkTextIter. Also bump minimum Julia version to 1.10 following Gtk4.